### PR TITLE
Fix stray backslashes

### DIFF
--- a/marsh
+++ b/marsh
@@ -1170,13 +1170,13 @@ function build_template {  # build_template dest_dir target_dir document templat
         # find template tags
         OIFS="${IFS}"
         IFS=$'\n'
-        TAGS=($(<"${DOCUMENT}" grep -Eo '\{\{[ ]*([a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)?)[ ]*(([ ]*\|[ ]*[a-z][a-z0-9-]*(\:[a-z0-9][a-z0-9-]*)*)*)[ ]*\}\}'))
+        TAGS=($(<"${DOCUMENT}" grep -Eo '\{\{[ ]*([a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)?)[ ]*(([ ]*\|[ ]*[a-z][a-z0-9-]*(:[a-z0-9][a-z0-9-]*)*)*)[ ]*\}\}'))
         IFS="${OIFS}"
 
         # loop over tags
         for I in "${!TAGS[@]}"; do
             TAG_ESC=$(echo "${TAGS[$I]}" | sed 's/[][/.|$(){}?+*^]/\\&/g')
-            TAG_VAL=$(echo "${TAGS[$I]}" | sed -E -e 's/\{\{[ ]*([a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)?)[ ]*(([ ]*\|[ ]*[a-z][a-z0-9-]*(\:[a-z0-9][a-z0-9-]*)*)*)[ ]*\}\}/\1\3/')
+            TAG_VAL=$(echo "${TAGS[$I]}" | sed -E -e 's/\{\{[ ]*([a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)?)[ ]*(([ ]*\|[ ]*[a-z][a-z0-9-]*(:[a-z0-9][a-z0-9-]*)*)*)[ ]*\}\}/\1\3/')
             TAG_NAME="${TAG_VAL%%|*}"
             TAG_FILTERS="${TAG_VAL#$TAG_NAME}"
             TAG_FILTERS=(${TAG_FILTERS//|/ })
@@ -1368,7 +1368,7 @@ function build_template {  # build_template dest_dir target_dir document templat
         for J in "${!PARTIALS[@]}"; do
             [[ "${PARTIALS[$J]}" == "" ]] && continue
             # grep to avoid unnecessary processing
-            if [[ "$(<${PARTIALS[$J]} grep -Eo '\{\%[ ]*if[ ]+')" != "" ]]; then
+            if [[ "$(<${PARTIALS[$J]} grep -Eo '\{%[ ]*if[ ]+')" != "" ]]; then
                 # template contains conditionals, operate using a copy
                 TEMPLATE_TEMP=$(mktemp "${MARSH_TEMP}/template-XXXXXX")
                 cp "${PARTIALS[$J]}" "${TEMPLATE_TEMP}"

--- a/marsh
+++ b/marsh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # marsh - build static websites using markdown and bash
 #
 # Copyright 2022 Bradley Sepos


### PR DESCRIPTION
GNU grep 3.8 started warning about backslashes before characters which shouldn't have them. This removes the unnecessary ones. I also switched the hashbang to a more portable one.